### PR TITLE
Add ability to read sitemap files locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ archiver --sitemaps https://alexgude.com/sitemap.xml
 
 This will backup every page listed in the sitemap of my website, [alexgude.com][ag].
 
+You can also pass a sitemap.xml file (requires the `file://` prefix) to the archiver:
+
+```bash
+archiver --sitemaps file://sitemap.xml
+```
+
 You can backup multiple pages by specifying multiple URLs or sitemaps:
 
 ```bash


### PR DESCRIPTION
You can load sitemaps via HTTP requests and load URLs via files. This PR lets you read a sitemap from a file.

You can also pass a sitemap.xml file (requires the `file://` prefix) to the archiver:

```bash
archiver --sitemaps file://sitemap.xml
```

 - Added code that first checks if the URL/URI passed the sitemap argument is a file path and attempts to read the file rather than fetch it via the network.

 - update README with details on archiving sitemap.xml file